### PR TITLE
acquisition: make query a PUT operation

### DIFF
--- a/api/ddbapi/app/models/base.py
+++ b/api/ddbapi/app/models/base.py
@@ -1,4 +1,5 @@
 import datetime
+from typing import Optional
 
 from bson import ObjectId
 from pydantic import BaseModel, Field
@@ -25,3 +26,17 @@ class DispimDbBase(BaseModel):
     added_by: datetime.datetime = Field(...)
     date_modified: datetime.datetime = Field(...)
     modified_by: datetime.datetime = Field(...)
+
+
+class MongoQueryModel(BaseModel):
+    filter: Optional[dict] = Field(None)
+    projection: Optional[dict] = Field(None)
+    skip: Optional[int] = Field(0)
+    limit: Optional[int] = Field(0)
+    sort: Optional[dict] = Field(None)
+    allow_partial_results: Optional[bool] = Field(False)
+    # batch_size
+    return_key: Optional[bool] = Field(None)
+    show_record_id: Optional[bool] = Field(None)
+    max_time_ms: Optional[int] = Field(None)
+    comment: Optional[str] = Field(None)

--- a/client/ddbclient/acquisition.py
+++ b/client/ddbclient/acquisition.py
@@ -160,7 +160,7 @@ class AcquisitionClient:
             'acquisition',
             'query')
 
-        response_json = utils.get_json(url, query_dict)
+        response_json = utils.put_json(url, query_dict)
         return response_json
 
     def put_data_location(self, acquisition_id, data_key, data_location):

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -142,3 +142,20 @@ def test_delete_acquisition(
         response_json = apiclient.acquisition.delete(acq['acquisition_id'])
 
         assert response_json is None
+
+
+def test_query_acquisitions(
+        apiclient, databased_good_acquisitions):
+    acquisitions_copy = copy.deepcopy(databased_good_acquisitions)
+    acq_ids = [acq["acquisition_id"] for acq in acquisitions_copy][:-1]
+
+    query = {
+        "filter": {"acquisition_id": {"$in": acq_ids}},
+        "projection": {"_id": False}
+    }
+    results = apiclient.acquisition.query(query)
+
+    result_acq_ids = [racq["acquisition_id"] for racq in results]
+    assert result_acq_ids == acq_ids
+
+    assert all([racq.get("_id") is None for racq in results])


### PR DESCRIPTION
changes acquisition/query to a PUT operation for arbitrary mongo find parameters as in #2 .  Unlike #2 , this adds a proper pydantic model and a test!