### PR TITLE
acquisitions: add support for unique index "acquisition_id"

### DIFF
--- a/api/ddbapi/db/db.py
+++ b/api/ddbapi/db/db.py
@@ -51,6 +51,27 @@ class DispimDBMongo:
     def find_one_and_update(self, collection, *args, **kwargs):
         return self._database[collection].find_one_and_update(*args, **kwargs)
 
+    @_mongoclient_retry
+    def create_indexes(self, collection, *args, **kwargs):
+        return self._database[collection].create_indexes(*args, **kwargs)
+
+    collection_indices = {
+        "acquisitions": [
+            pymongo.IndexModel(
+                [("acquisition_id", pymongo.ASCENDING)],
+                unique=True),
+        ],
+    }
+
+    def add_document(self, collection, *args, **kwargs):
+        try:
+            self.create_indexes(
+                collection,
+                self.collection_indices[collection])
+        except KeyError:
+            pass
+        return self.insert_one(collection, *args, **kwargs)
+
 
 dispimdb_mongo = DispimDBMongo(DATABASE_URI, DATABASE_NAME)
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -24,6 +24,20 @@ def test_create_acquisition(mongo_delete_acq_after, good_acquisitions):
                 acquisition['acquisition_id'])
 
 
+def test_create_acquisition_exists(databased_good_acquisitions):
+    acquisition = databased_good_acquisitions[-1]
+
+    acquisition_url = "api/new_acquisition"
+
+    excluded_fields = {"acquisition_id", "_id"}
+    post_acq = copy.deepcopy(
+        {k: acquisition[k] for k in acquisition.keys() - excluded_fields})
+
+    response = client.post(acquisition_url, json=post_acq)
+
+    assert response.status_code == 409
+
+
 def test_get_acquisitions(
         mongo_insert_delete_acq, good_acquisitions, specimen_id):
     acq_list = []

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -31,6 +31,17 @@ def test_post_acquisition(
         assert acq['acquisition_id'] == acq_id
 
 
+def test_post_acquisition_existing(
+        apiclient, databased_good_acquisitions):
+    acq = databased_good_acquisitions[0]
+    excluded_fields = {"acquisition_id", "_id"}
+    post_acq = copy.deepcopy(
+        {k: acq[k] for k in acq.keys() - excluded_fields})
+
+    with pytest.raises(Exception):
+        _ = apiclient.acquisition.post(post_acq)
+
+
 def test_get_acquisitions(
         apiclient, databased_good_acquisitions, specimen_id):
     acq_list = []


### PR DESCRIPTION
adds support for creating mongodb indices and adds default indices for the acquisitions collection.  Implements "acquisition_id" as a unique index for this collection and returns a 409 conflict when trying to POST a duplicate in the api.