### PR TITLE
acquisition: update data_location state table to match ac data mover

### DIFF
--- a/api/ddbapi/db/states.py
+++ b/api/ddbapi/db/states.py
@@ -1,22 +1,11 @@
-states = [
-    'NOT_STARTED',
-    'STARTED',
-    'IN_PROGRESS',
-    'COMPLETED',
-    'STOPPED',
-    'ERROR'
-]
-
-allowed_transitions = {
-    'NOT_STARTED': ['STARTED', 'ERROR'],
-    'STARTED': ['IN_PROGRESS', 'ERROR'],
-    'IN_PROGRESS': ['COMPLETED', 'STOPPED', 'ERROR'],
-    'COMPLETED': ['NOT_STARTED'],
-    'STOPPED': ['ERROR', 'NOT_STARTED' 'STARTED'],
-    'ERROR': ['STOPPED'],
+data_location_allowed_transitions = {
+    "CREATING": ["CREATE_ERROR", "COMPLETE"],
+    "CREATE_ERROR": ["CREATING", "DELETING"],
+    "COMPLETE": ["DELETING"],
+    "DELETING": ["DELETE_ERROR", "DELETED"],
+    "DELETE_ERROR": ["CREATING", "DELETING"],
+    "DELETED": ["CREATING"]
 }
-
-data_location_allowed_transitions = allowed_transitions
 
 
 class StateTable:
@@ -57,3 +46,5 @@ class StateTable:
 
 data_location_state_table = StateTable.from_dict(
     data_location_allowed_transitions)
+
+__all__ = ["StateTable", "data_location_state_table"]

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -61,7 +61,7 @@ def test_get_acquisition(mongo_insert_delete_acq, good_acquisitions):
 def test_put_data_location(mongo_insert_delete_acq, good_acquisitions):
     n5_directory = {
         'name': 'my_n5_dir',
-        'status': 'STARTED'
+        'status': 'CREATING'
     }
 
     for acquisition in good_acquisitions:
@@ -85,7 +85,7 @@ def test_put_data_location(mongo_insert_delete_acq, good_acquisitions):
 def test_patch_data_location_status(
         mongo_insert_delete_acq, good_acquisitions):
     data_key = 'tiff_directory'
-    new_state = 'IN_PROGRESS'
+    new_state = 'COMPLETE'
 
     for acquisition in good_acquisitions:
         if '_id' in acquisition:

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -56,7 +56,7 @@ def test_put_data_location(
     data_key = 'n5_directory'
     n5_directory = {
         'name': 'my_n5_dir',
-        'status': 'STARTED'
+        'status': 'CREATING'
     }
 
     for acq in databased_good_acquisitions:
@@ -72,7 +72,7 @@ def test_put_data_location(
 def test_patch_data_location_status(
         apiclient, databased_good_acquisitions):
     data_key = 'tiff_directory'
-    new_state = 'IN_PROGRESS'
+    new_state = 'COMPLETE'
 
     for acq in databased_good_acquisitions:
 
@@ -88,7 +88,7 @@ def test_patch_data_location_status(
 def test_bad_transition_patch_data_location_status(
         apiclient, databased_good_acquisitions):
     data_key = "tiff_directory"
-    new_state = "NOT_STARTED"
+    new_state = "DELETED"
 
     for acq in databased_good_acquisitions:
         with pytest.raises(Exception):
@@ -106,7 +106,7 @@ def test_bad_transition_patch_data_location_status(
 def test_bad_acquisition_patch_data_location_status(
         apiclient, databased_good_acquisitions):
     data_key = "tiff_directory"
-    new_state = "IN_PROGRESS"
+    new_state = "COMPLETE"
 
     acquisition_id = "not_an_acqid"
 

--- a/tests/test_data/acquisition_data.py
+++ b/tests/test_data/acquisition_data.py
@@ -24,7 +24,7 @@ acq_good_doc = [
         'data_location': {
             'tiff_directory': {
                 'name': 'my_dir',
-                'status': 'STARTED',
+                'status': 'CREATING',
             }
         }
     },
@@ -38,7 +38,7 @@ acq_good_doc = [
         'data_location': {
             'tiff_directory': {
                 'name': 'H17_B4_S3_16x_0.5xPBS_overview_25um_step_size_1000um_delta_y',
-                'status': 'STARTED'
+                'status': 'CREATING'
             }
         },
     },
@@ -52,7 +52,7 @@ acq_good_doc = [
         'data_location': {
             'tiff_directory': {
                 'name': 'tiff2',
-                'status': 'STARTED'
+                'status': 'CREATING'
             }
         }
     }
@@ -67,16 +67,6 @@ acq_bad_doc = [
     ({}, 404),
     ({}, 404),
     ({}, 404)
-]
-
-acq_good_state_transitions = [
-    ['STARTED', 'IN_PROGRESS'],
-    ['IN_PROGRESS', 'COMPLETED'],
-    ['STARTED', 'ERROR']
-]
-acq_bad_state_transitions = [
-    ['STARTED', 'COMPLETED'],
-    ['COMPLETED', 'IN_PROGRESS']
 ]
 
 acq_good_query = []


### PR DESCRIPTION
change data_location states to use the same states used in the ac_data_mover demo.  These are focused on the state of the resource the data location is tracking rather than an arbitrary operation.