### PR TITLE
client: remove support for host, port, subpath in favor of base_url

### DIFF
--- a/client/ddbclient/acquisition.py
+++ b/client/ddbclient/acquisition.py
@@ -16,12 +16,6 @@ class AcquisitionClient(ddbclient.base.BaseClient):
     ----------
     base_url : str
         Base url of the api (e.g. http://bigkahuna.corp.alleninstitute.org/api)
-    hostname : str
-        Name of API host (e.g. http://bigkahuna.corp.alleninstitute.org)
-    port : str
-        Port number for API (e.g. 8000)
-    subpath : str
-        Specifies path to api and version (e.g. 'api/v1')
 
     Methods
     -------

--- a/client/ddbclient/base.py
+++ b/client/ddbclient/base.py
@@ -1,39 +1,9 @@
-import posixpath
-
-
 class BaseClient:
-    def __init__(self,
-                 base_url=None,
-                 hostname=None,
-                 port=None,
-                 subpath=None):
+    def __init__(self, base_url=None):
         """
         Parameters
         ----------
         base_url : str
             Base url of the api (e.g. http://bigkahuna.corp.alleninstitute.org/api)
-        hostname : str
-            Name of API host (e.g. http://bigkahuna.corp.alleninstitute.org)
-        port : str
-            Port number for API (e.g. 8000)
-        subpath : str
-            Specifies path to api and version (e.g. 'api/v1')
         """
         self.base_url = base_url
-        self.hostname = hostname
-        self.port = port
-        self.subpath = subpath
-
-        if self.port is not None:
-            self.hostname = self.hostname + ':' + self.port
-
-        if self.base_url is None:
-            self.base_url = posixpath.join(
-                self.hostname,
-                self.subpath
-            )
-        else:
-            self.base_url = posixpath.join(
-                self.base_url,
-                self.subpath
-            )

--- a/client/ddbclient/client.py
+++ b/client/ddbclient/client.py
@@ -3,15 +3,8 @@ from ddbclient import (
 
 
 class DispimDbClient:
-    def __init__(self,
-                 base_url=None,
-                 hostname=None,
-                 port=None,
-                 subpath=None):
+    def __init__(self, base_url=None):
         self.base_url = base_url
-        self.hostname = hostname
-        self.port = port
-        self.subpath = subpath
 
         self._register_client("acquisition", acquisition.AcquisitionClient)
         self._register_client("specimen", specimen.SpecimenClient)
@@ -20,8 +13,5 @@ class DispimDbClient:
 
     def _register_client(self, client_name, client_class):
         client_obj = client_class(**{
-            "base_url": self.base_url,
-            "hostname": self.hostname,
-            "port": self.port,
-            "subpath": self.subpath})
+            "base_url": self.base_url})
         setattr(self, client_name, client_obj)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -8,8 +8,7 @@ from client.ddbclient import client
 @pytest.fixture(scope="session")
 def apiclient(ddbapi_endpoint_url):
     yield client.DispimDbClient(
-        base_url=ddbapi_endpoint_url,
-        subpath=""  # FIXME subpath currently required
+        base_url=ddbapi_endpoint_url
     )
 
 


### PR DESCRIPTION
removes support for host + port + subpath specification in favor of just using base_url. Previous behavior always required a subpath (even when api was fully qualified in the base url), and I don't see the use case for the more complicated logic at this point.